### PR TITLE
Pass IGrainActivationContext to IActivity for extensibility

### DIFF
--- a/Orleans.Sagas/Activity.cs
+++ b/Orleans.Sagas/Activity.cs
@@ -1,6 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Orleans.Runtime;
-using System;
 
 namespace Orleans.Sagas
 {
@@ -11,26 +12,25 @@ namespace Orleans.Sagas
 
     public abstract class Activity : IActivity
     {
-        public virtual string Name => this.GetType().Name;
         [NonSerialized]
-        private IGrainFactory grainFactory;
-        [NonSerialized]
-        private Guid guid;
-        [NonSerialized]
-        private Logger logger;
+        private Guid sagaId;
 
-        public void Initialize(Guid sagaId, IGrainFactory grainFactory, Logger logger)
+        [NonSerialized]
+        private IGrainActivationContext grainContext;
+
+        public virtual string Name => this.GetType().Name;
+
+        public void Initialize(Guid sagaId, IGrainActivationContext grainContext)
         {
-            SagaId = sagaId;
-            GrainFactory = grainFactory;
-            Logger = logger;
+            this.sagaId = sagaId;
+            this.grainContext = grainContext;
         }
 
         public abstract Task Execute();
         public abstract Task Compensate();
 
-        protected Guid SagaId { get { return guid; } private set { guid = value; } }
-        protected IGrainFactory GrainFactory { get { return grainFactory; } private set { grainFactory = value; } }
-        protected Logger Logger { get { return logger; } private set { logger = value; } }
+        protected Guid SagaId { get { return sagaId; } }
+        protected IGrainActivationContext GrainContext { get { return grainContext; } }
+        protected IGrainFactory GrainFactory { get { return grainContext.ActivationServices.GetRequiredService<IGrainFactory>(); } }
     }
 }

--- a/Orleans.Sagas/IActivity.cs
+++ b/Orleans.Sagas/IActivity.cs
@@ -7,7 +7,7 @@ namespace Orleans.Sagas
     public interface IActivity
     {
         string Name { get; }
-        void Initialize(Guid sagaId, IGrainFactory grainFactory, Logger logger);
+        void Initialize(Guid sagaId, IGrainActivationContext grainContext);
         Task Execute();
         Task Compensate();
     }

--- a/Orleans.Sagas/SagaGrain.cs
+++ b/Orleans.Sagas/SagaGrain.cs
@@ -12,7 +12,13 @@ namespace Orleans.Sagas
     {
         private static string ReminderName = typeof(SagaGrain).Name;
 
+        private readonly IGrainActivationContext grainContext;
         private bool isActive;
+
+        public SagaGrain(IGrainActivationContext grainContext)
+        {
+            this.grainContext = grainContext;
+        }
 
         public async Task RequestAbort()
         {
@@ -148,7 +154,7 @@ namespace Orleans.Sagas
 
                 try
                 {
-                    currentActivity.Initialize(this.GetPrimaryKey(), GrainFactory, GetLogger());
+                    currentActivity.Initialize(this.GetPrimaryKey(), this.grainContext);
                     GetLogger().Verbose($"Executing activity #{State.NumCompletedActivities} '{currentActivity.Name}'...");
                     await currentActivity.Execute();
                     GetLogger().Verbose($"...activity #{State.NumCompletedActivities} '{currentActivity.Name}' complete.");
@@ -177,7 +183,7 @@ namespace Orleans.Sagas
                 {
                     var currentActivity = State.Activities[State.CompensationIndex];
 
-                    currentActivity.Initialize(this.GetPrimaryKey(), GrainFactory, GetLogger());
+                    currentActivity.Initialize(this.GetPrimaryKey(), this.grainContext);
                     GetLogger().Verbose(0, $"Compensating for activity #{State.CompensationIndex} '{currentActivity.Name}'...");
                     await currentActivity.Compensate();
                     GetLogger().Verbose(0, $"...activity #{State.CompensationIndex} '{currentActivity.Name}' compensation complete.");


### PR DESCRIPTION
Pass `IGrainActivationContext` to `IActivity`, so that the activity can have access to all scoped and application services, instead of restricted access to just the grain factory and the logger.