### PR TITLE
Update to Orleans 2.0.0-beta1 packages for .NET Core 2.0 platform.

### DIFF
--- a/Orleans.Sagas.Samples/Activities/KickAssActivity.cs
+++ b/Orleans.Sagas.Samples/Activities/KickAssActivity.cs
@@ -4,13 +4,14 @@ namespace Orleans.Sagas.Samples.Activities
 {
     public class KickAssActivity : Activity<KickAssConfig>
     {
-        public override async Task Execute()
+        public override Task Execute()
         {
             //Logger.Info($"Kicking ass {Config.KickAssCount} times...");
             for (int i = 0; i < Config.KickAssCount; i++)
             {
                 //Logger.Info("Ass kicked.");
             }
+            return Task.CompletedTask;
         }
 
         public override Task Compensate()

--- a/Orleans.Sagas.Samples/Orleans.Sagas.Samples.csproj
+++ b/Orleans.Sagas.Samples/Orleans.Sagas.Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,10 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-20170724" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator" Version="2.0.0-preview2-20170724" />
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.0.0-preview2-20170724" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-preview2-20170724" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-beta1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-beta1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.0.0-beta1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-beta1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Orleans.Sagas.Tests/Orleans.Sagas.Tests.csproj
+++ b/Orleans.Sagas.Tests/Orleans.Sagas.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Moq" Version="4.7.142" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Orleans.Sagas/Orleans.Sagas.csproj
+++ b/Orleans.Sagas/Orleans.Sagas.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-preview2-20170724" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-beta1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
- Update `Orleans.*` packages to version `2.0.0-beta1` for .NET Core 2.0 support.

- Upgrade `Orleans.Sagas.*` projects to use .NET Core 2.0 build framework monikers `netstandard2.0` or `netcoreapp2.0` as applicable.

- Update test framework libraries to latest stable versions.